### PR TITLE
Create a report for tenants that have no providers.

### DIFF
--- a/kokudaily/reports.py
+++ b/kokudaily/reports.py
@@ -59,6 +59,10 @@ REPORTS = {
         "file": "sql/incomplete_manifests.sql",
         "target": "engineering",
     },
+    "empty_tenants": {
+        "file": "sql/empty_tenants.sql",
+        "target": "engineering",
+    },
 }
 
 

--- a/kokudaily/sql/empty_tenants.sql
+++ b/kokudaily/sql/empty_tenants.sql
@@ -1,0 +1,8 @@
+SELECT cust.*,
+       t.id AS tenant_id
+FROM   PUBLIC.api_customer AS cust
+       LEFT JOIN PUBLIC.api_provider p
+              ON cust.id = p.customer_id
+       JOIN PUBLIC.api_tenant t
+         ON cust.schema_name = t.schema_name
+WHERE  p.customer_id IS NULL  

--- a/kokudaily/sql/over_48_hours_status_providers.sql
+++ b/kokudaily/sql/over_48_hours_status_providers.sql
@@ -1,8 +1,11 @@
- SELECT t.*,
-       cust.account_id
-FROM   PUBLIC.api_provider t
-JOIN   PUBLIC.api_providerstatus AS status
-ON     t.uuid = status.provider_id
-JOIN   PUBLIC.api_customer AS cust
-ON     t.customer_id = cust.id
-WHERE  status.timestamp <= Now() - interval '48 HOURS'
+SELECT    cust.account_id,
+          t.*
+FROM      PUBLIC.api_provider t
+LEFT JOIN PUBLIC.api_sources AS sources
+ON        t.uuid :: text = sources.koku_uuid
+JOIN      PUBLIC.api_providerstatus AS status
+ON        t.uuid = status.provider_id
+JOIN      PUBLIC.api_customer AS cust
+ON        t.customer_id = cust.id
+WHERE     status.timestamp <= now() - interval '48 HOURS'
+AND       sources.koku_uuid IS NOT NULL 


### PR DESCRIPTION
* We could potentially reduce the number of tenants we have to perform migrations on
* Update 48 hour check to ignore providers which have no source