### PR TITLE
Reduce rows returned by report

### DIFF
--- a/kokudaily/sql/incomplete_manifests.sql
+++ b/kokudaily/sql/incomplete_manifests.sql
@@ -5,19 +5,15 @@ SELECT    c.id as customer_id,
           rm.assembly_id,
           rm.manifest_creation_datetime,
           rm.manifest_updated_datetime,
+          rm.manifest_completed_datetime,
           rm.billing_period_start_datetime,
           rm.num_processed_files,
-          rm.num_total_files,
-          rs.report_name,
-          rs.last_started_datetime as report_start_datetime,
-          rs.last_completed_datetime as report_completed_datetime
+          rm.num_total_files
 FROM      public.reporting_common_costusagereportmanifest AS rm
 JOIN      public.api_provider AS p
 ON        rm.provider_id = p.uuid
 JOIN      public.api_customer AS c
 ON        p.customer_id = c.id
-LEFT JOIN public.reporting_common_costusagereportstatus AS rs
-ON        rm.id = rs.manifest_id
 WHERE     num_processed_files != num_total_files
 AND       manifest_creation_datetime >= current_date - INTERVAL '1 day'
 ORDER BY  c.id,


### PR DESCRIPTION
## Summary
Instead of returning a row with every report file in the manifest, just return a single row for the manifest. 