### PR TITLE
Use status table for report counts

### DIFF
--- a/kokudaily/sql/incomplete_manifests.sql
+++ b/kokudaily/sql/incomplete_manifests.sql
@@ -7,15 +7,26 @@ SELECT    c.id as customer_id,
           rm.manifest_updated_datetime,
           rm.manifest_completed_datetime,
           rm.billing_period_start_datetime,
-          rm.num_processed_files,
-          rm.num_total_files
+          counts.num_processed_files,
+          counts.num_total_files
 FROM      public.reporting_common_costusagereportmanifest AS rm
 JOIN      public.api_provider AS p
 ON        rm.provider_id = p.uuid
 JOIN      public.api_customer AS c
 ON        p.customer_id = c.id
-WHERE     num_processed_files != num_total_files
-AND       manifest_creation_datetime >= current_date - INTERVAL '1 day'
+JOIN (
+    SELECT   rm.id,
+             count(rs.*) FILTER (WHERE last_completed_datetime IS NOT NULL) AS num_processed_files,
+             count(rs.*) AS num_total_files
+    FROM     public.reporting_common_costusagereportmanifest AS rm
+    JOIN     public.reporting_common_costusagereportstatus AS rs
+    ON       rm.id = rs.manifest_id
+    GROUP BY rm.id
+) AS counts
+ON        rm.id = counts.id
+WHERE     counts.num_processed_files != counts.num_total_files
+AND       rm.manifest_creation_datetime >= current_date - INTERVAL '1 day'
+AND       rm.manifest_updated_datetime < now() - INTERVAL '10 min' -- It has been longer than 10 minutes since we processed anything
 ORDER BY  c.id,
           p.type,
           rm.manifest_creation_datetime

--- a/kokudaily/sql/incomplete_manifests.sql
+++ b/kokudaily/sql/incomplete_manifests.sql
@@ -4,7 +4,7 @@ SELECT    c.id as customer_id,
           p.type as source_type,
           rm.assembly_id,
           rm.manifest_creation_datetime,
-          rm.manifest_updated_datetime,
+          counts.manifest_updated_datetime,
           rm.manifest_completed_datetime,
           rm.billing_period_start_datetime,
           counts.num_processed_files,
@@ -17,7 +17,8 @@ ON        p.customer_id = c.id
 JOIN (
     SELECT   rm.id,
              count(rs.*) FILTER (WHERE last_completed_datetime IS NOT NULL) AS num_processed_files,
-             count(rs.*) AS num_total_files
+             count(rs.*) AS num_total_files,
+             max(rs.last_completed_datetime) as manifest_updated_datetime
     FROM     public.reporting_common_costusagereportmanifest AS rm
     JOIN     public.reporting_common_costusagereportstatus AS rs
     ON       rm.id = rs.manifest_id
@@ -26,7 +27,7 @@ JOIN (
 ON        rm.id = counts.id
 WHERE     counts.num_processed_files != counts.num_total_files
 AND       rm.manifest_creation_datetime >= current_date - INTERVAL '1 day'
-AND       rm.manifest_updated_datetime < now() - INTERVAL '10 min' -- It has been longer than 10 minutes since we processed anything
+AND       counts.manifest_updated_datetime < now() - INTERVAL '10 min' -- It has been longer than 10 minutes since we processed anything
 ORDER BY  c.id,
           p.type,
           rm.manifest_creation_datetime


### PR DESCRIPTION
## Summary
This updates the incomplete manifest query to rely on the file status table for counting incomplete processing. This also adds a check to make sure it has been more than 10 minutes since the last file processing completed to try to skip false positives in this report. We were reporting on long running manifests that were still processing. 