### PR TITLE
Updating reports to use manifest completion date

### DIFF
--- a/kokudaily/sql/active_providers.sql
+++ b/kokudaily/sql/active_providers.sql
@@ -1,11 +1,24 @@
+CREATE TEMPORARY TABLE manifest_temp AS (
+    SELECT  DISTINCT ON(provider_id)
+            provider_id,
+            billing_period_start_datetime,
+            manifest_completed_datetime
+    FROM PUBLIC.reporting_common_costusagereportmanifest
+    ORDER BY provider_id,
+             billing_period_start_datetime
+    DESC NULLS LAST
+);
+
 SELECT    cust.account_id,
           t.*
 FROM      PUBLIC.api_provider t
 LEFT JOIN PUBLIC.api_sources AS sources
 ON        t.uuid :: text = sources.koku_uuid
-JOIN      PUBLIC.api_providerstatus AS status
+JOIN      manifest_temp AS status
 ON        t.uuid = status.provider_id
 JOIN      PUBLIC.api_customer AS cust
 ON        t.customer_id = cust.id
-WHERE     status.timestamp >= now() - interval '48 HOURS'
+WHERE     status.manifest_completed_datetime >= now() - interval '48 HOURS'
 AND       sources.koku_uuid IS NOT NULL
+;
+DROP TABLE manifest_temp;

--- a/kokudaily/sql/active_providers.sql
+++ b/kokudaily/sql/active_providers.sql
@@ -1,11 +1,11 @@
 CREATE TEMPORARY TABLE manifest_temp AS (
     SELECT  DISTINCT ON(provider_id)
             provider_id,
-            billing_period_start_datetime,
+            id,
             manifest_completed_datetime
     FROM PUBLIC.reporting_common_costusagereportmanifest
     ORDER BY provider_id,
-             billing_period_start_datetime
+             id
     DESC NULLS LAST
 );
 

--- a/kokudaily/sql/count_active_providers.sql
+++ b/kokudaily/sql/count_active_providers.sql
@@ -1,13 +1,27 @@
-SELECT    count (DISTINCT t.*),
+CREATE TEMPORARY TABLE manifest_temp AS (
+    SELECT  DISTINCT ON(provider_id)
+            provider_id,
+            billing_period_start_datetime,
+            manifest_completed_datetime
+    FROM PUBLIC.reporting_common_costusagereportmanifest
+    ORDER BY provider_id,
+             billing_period_start_datetime
+    DESC NULLS LAST
+);
+
+SELECT    DISTINCT ON(status.provider_id)
+          count (DISTINCT t.*),
           cust.account_id,
           t.type as source_type
 FROM      PUBLIC.api_provider t
 LEFT JOIN PUBLIC.api_sources AS sources
 ON        t.uuid :: text = sources.koku_uuid
-JOIN      PUBLIC.api_providerstatus AS status
+JOIN      manifest_temp AS status
 ON        t.uuid = status.provider_id
 JOIN      PUBLIC.api_customer AS cust
 ON        t.customer_id = cust.id
-WHERE     status.timestamp >= now() - interval '48 HOURS'
+WHERE     status.manifest_completed_datetime >= now() - interval '48 HOURS'
 AND       sources.koku_uuid IS NOT NULL
-GROUP BY cust.account_id, t.type
+GROUP BY cust.account_id, t.type, status.provider_id
+;
+DROP TABLE manifest_temp;

--- a/kokudaily/sql/count_active_providers.sql
+++ b/kokudaily/sql/count_active_providers.sql
@@ -1,11 +1,11 @@
 CREATE TEMPORARY TABLE manifest_temp AS (
     SELECT  DISTINCT ON(provider_id)
             provider_id,
-            billing_period_start_datetime,
+            id,
             manifest_completed_datetime
     FROM PUBLIC.reporting_common_costusagereportmanifest
     ORDER BY provider_id,
-             billing_period_start_datetime
+             id
     DESC NULLS LAST
 );
 

--- a/kokudaily/sql/count_stale_providers.sql
+++ b/kokudaily/sql/count_stale_providers.sql
@@ -1,13 +1,26 @@
+CREATE TEMPORARY TABLE manifest_temp AS (
+    SELECT  DISTINCT ON(provider_id)
+            provider_id,
+            billing_period_start_datetime,
+            manifest_completed_datetime
+    FROM PUBLIC.reporting_common_costusagereportmanifest
+    ORDER BY provider_id,
+             billing_period_start_datetime
+    DESC NULLS LAST
+);
+
 SELECT    count (DISTINCT t.*),
           cust.account_id,
           t.type as source_type
 FROM      PUBLIC.api_provider t
 LEFT JOIN PUBLIC.api_sources AS sources
 ON        t.uuid :: text = sources.koku_uuid
-JOIN      PUBLIC.api_providerstatus AS status
+JOIN      manifest_temp AS status
 ON        t.uuid = status.provider_id
 JOIN      PUBLIC.api_customer AS cust
 ON        t.customer_id = cust.id
-WHERE     status.timestamp <= now() - interval '48 HOURS'
+WHERE     status.manifest_completed_datetime <= now() - interval '48 HOURS'
 AND       sources.koku_uuid IS NOT NULL
-GROUP BY cust.account_id, t.type
+GROUP BY cust.account_id, t.type, status.provider_id
+;
+DROP TABLE manifest_temp;

--- a/kokudaily/sql/count_stale_providers.sql
+++ b/kokudaily/sql/count_stale_providers.sql
@@ -1,11 +1,11 @@
 CREATE TEMPORARY TABLE manifest_temp AS (
     SELECT  DISTINCT ON(provider_id)
             provider_id,
-            billing_period_start_datetime,
+            id,
             manifest_completed_datetime
     FROM PUBLIC.reporting_common_costusagereportmanifest
     ORDER BY provider_id,
-             billing_period_start_datetime
+             id
     DESC NULLS LAST
 );
 

--- a/kokudaily/sql/stale_providers.sql
+++ b/kokudaily/sql/stale_providers.sql
@@ -1,11 +1,24 @@
+CREATE TEMPORARY TABLE manifest_temp AS (
+    SELECT  DISTINCT ON(provider_id)
+            provider_id,
+            billing_period_start_datetime,
+            manifest_completed_datetime
+    FROM PUBLIC.reporting_common_costusagereportmanifest
+    ORDER BY provider_id,
+             billing_period_start_datetime
+    DESC NULLS LAST
+);
+
 SELECT    cust.account_id,
           t.*
 FROM      PUBLIC.api_provider t
 LEFT JOIN PUBLIC.api_sources AS sources
 ON        t.uuid :: text = sources.koku_uuid
-JOIN      PUBLIC.api_providerstatus AS status
+JOIN      manifest_temp AS status
 ON        t.uuid = status.provider_id
 JOIN      PUBLIC.api_customer AS cust
 ON        t.customer_id = cust.id
-WHERE     status.timestamp <= now() - interval '48 HOURS'
+WHERE     status.manifest_completed_datetime <= now() - interval '48 HOURS'
 AND       sources.koku_uuid IS NOT NULL
+;
+DROP TABLE manifest_temp;

--- a/kokudaily/sql/stale_providers.sql
+++ b/kokudaily/sql/stale_providers.sql
@@ -1,11 +1,11 @@
 CREATE TEMPORARY TABLE manifest_temp AS (
     SELECT  DISTINCT ON(provider_id)
             provider_id,
-            billing_period_start_datetime,
+            id,
             manifest_completed_datetime
     FROM PUBLIC.reporting_common_costusagereportmanifest
     ORDER BY provider_id,
-             billing_period_start_datetime
+             id
     DESC NULLS LAST
 );
 


### PR DESCRIPTION
The provider status timestamp is not reliable and I have found several problems in the reports with respect to stale and active providers when running this query in CI and comparing to our latest CI engineering report.

