### PR TITLE
COST-549: add deploymentConfig; expand config to listen on any address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 openshift/parameters.properties
 
 .vscode/
+*.sw[po]

--- a/app.py
+++ b/app.py
@@ -58,4 +58,4 @@ def display_page(pathname):
         return html.Div([html.H3(f"Unknown page {pathname}")])
 
 
-app.run_server(debug=True, port=Config.APP_PORT)
+app.run_server(debug=True, host=Config.APP_HOST, port=Config.APP_PORT)

--- a/kokudaily/config.py
+++ b/kokudaily/config.py
@@ -21,9 +21,7 @@ class Config:
     DB_HOST = os.getenv("DATABASE_HOST", "localhost")
     DB_PORT = os.getenv("DATABASE_PORT", "15432")
 
-    SQLALCHEMY_DATABASE_URI = (
-        f"{DB_ENGINE}://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
-    )
+    SQLALCHEMY_DATABASE_URI = f"{DB_ENGINE}://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
@@ -42,7 +40,13 @@ class Config:
             EMAIL_GROUPS = {}
 
     PROMETHEUS_PUSH_GATEWAY = os.getenv("PROMETHEUS_PUSH_GATEWAY")
+
+    APP_HOST = os.getenv("APP_HOST", "127.0.0.1")
     APP_PORT = os.getenv("APP_PORT", "8080")
+
+    if APP_HOST != "127.0.0.1":
+        LOG.info("Listening on %s:%s. This might be insecure.", APP_HOST, APP_PORT)
+
     try:
         APP_PORT = int(APP_PORT)
     except ValueError:

--- a/openshift/koku-daily.yaml
+++ b/openshift/koku-daily.yaml
@@ -89,6 +89,15 @@ objects:
     email_user: ${EMAIL_USER}
     email_password: ${EMAIL_PASSWORD}
 
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    labels:
+      app: ${NAME}
+    name: rds-client-ca
+  stringData:
+    rds-cacert: "SSL CERTIFICATE GOES HERE"
+
 - apiVersion: batch/v1beta1
   kind: CronJob
   metadata:
@@ -169,6 +178,114 @@ objects:
                       - key: rds-cacert
                         path: server.pem
 
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    name: ${NAME}-ui
+  spec:
+    replicas: ${{REPLICAS}}
+    selector:
+      name: koku-daily-ui
+    template:
+      metadata:
+        labels:
+          app: koku
+          name: koku-daily-ui
+        name: koku-daily-ui
+      spec:
+        containers:
+        - name: koku-daily-ui
+          image: koku-daily
+          imagePullPolicy: Always
+          command: ["python", "app.py"]
+          volumeMounts:
+          - name: ssl-cert
+            mountPath: /etc/ssl/certs
+            readOnly: true
+          env:
+            - name: APP_HOST
+              value: '0.0.0.0'
+            - name: APP_PORT
+              value: '8080'
+            - name: DATABASE_HOST
+              valueFrom:
+                secretKeyRef:
+                  key: db.host
+                  name: koku-db
+                  optional: false
+            - name: DATABASE_PORT
+              valueFrom:
+                secretKeyRef:
+                  key: db.port
+                  name: koku-db
+                  optional: false
+            - name: DATABASE_NAME
+              valueFrom:
+                secretKeyRef:
+                  key: db.name
+                  name: koku-db
+                  optional: false
+            - name: DATABASE_USER
+              valueFrom:
+                secretKeyRef:
+                  key: db.user
+                  name: koku-db
+                  optional: false
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: db.password
+                  name: koku-db
+                  optional: false
+            - name: EMAIL_USER
+              valueFrom:
+                secretKeyRef:
+                  key: email_user
+                  name: koku-daily-secret
+                  optional: false
+            - name: EMAIL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: email_password
+                  name: koku-daily-secret
+                  optional: false
+            - name: EMAIL_GROUPS
+              value: ${EMAIL_GROUPS}
+            - name: PROMETHEUS_PUSH_GATEWAY
+              value: ${PROMETHEUS_PUSH_GATEWAY}
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+        restartPolicy: Always
+        volumes:
+        - name: ssl-cert
+          projected:
+            sources:
+            - secret:
+                name: rds-client-ca
+                items:
+                  - key: rds-cacert
+                    path: server.pem
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: Exposes and load balances the application pods
+    name: koku-daily
+  spec:
+    ports:
+    - name: 8080-tcp
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      name: koku-daily
+
 parameters:
 - description: The name assigned to all frontend objects defined in this template.
   displayName: Name
@@ -242,3 +359,8 @@ parameters:
 - displayName: PROMETHEUS_PUSH_GATEWAY
   name: PROMETHEUS_PUSH_GATEWAY
   required: true
+- description: The number of replicas to keep
+  displayName: Replica minimum
+  name: REPLICAS
+  required: true
+  value: '0'


### PR DESCRIPTION
This PR does a couple things to enable the info to be exposed via the UI.

- Add a DeploymentConfig, Secret, and Service to the openshift template.
- Update the app config to allow listening on a configurable address.