### PR TITLE
add support for a URL prefix

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import sys
 
 import dash
@@ -14,14 +15,13 @@ root.setLevel(logging.INFO)
 
 handler = logging.StreamHandler(sys.stdout)
 handler.setLevel(logging.INFO)
-formatter = logging.Formatter(
-    "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-)
+formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 handler.setFormatter(formatter)
 root.addHandler(handler)
 
 LOG = logging.getLogger(__name__)
 CSS = ["https://codepen.io/chriddyp/pen/bWLwgP.css"]
+
 CHART_PATHS = {
     "/": {"name": "Index", "view": display_index},
     "/marketing": {"name": "Marketing", "view": display_marketing},
@@ -37,7 +37,7 @@ div_list = []
 div_list.append(dcc.Location(id="url", refresh=False))
 
 for key, value in CHART_PATHS.items():
-    div_list.append(dcc.Link(value.get("name", "Missing Link Name"), href=key))
+    div_list.append(dcc.Link(value.get("name", "Missing Link Name"), href=Config.APP_URL_PREFIX + key))
     div_list.append(html.Br())
 
 # content will be rendered in this element
@@ -46,16 +46,17 @@ app.layout = html.Div(div_list)
 
 
 @app.callback(
-    dash.dependencies.Output("page-content", "children"),
-    [dash.dependencies.Input("url", "pathname")],
+    dash.dependencies.Output("page-content", "children"), [dash.dependencies.Input("url", "pathname")],
 )
 def display_page(pathname):
     LOG.info(f"Hitting path {pathname}.")
+    if pathname and Config.APP_URL_PREFIX in pathname:
+        pathname = re.sub(Config.APP_URL_PREFIX, "", pathname)
     view = CHART_PATHS.get(pathname, {}).get("view")
     if view:
         return view()
     else:
-        return html.Div([html.H3(f"Unknown page {pathname}")])
+        return html.Div([html.H3(f"Unknown page {Config.APP_URL_PREFIX}{pathname}")])
 
 
 app.run_server(debug=True, host=Config.APP_HOST, port=Config.APP_PORT)

--- a/kokudaily/config.py
+++ b/kokudaily/config.py
@@ -52,3 +52,5 @@ class Config:
     except ValueError:
         LOG.info("Defined APP_PORT was not an integer; defaulting to 8080.")
         APP_PORT = 8080
+
+    APP_URL_PREFIX = os.getenv("APP_URL_PREFIX", "")

--- a/openshift/example.parameters.properties
+++ b/openshift/example.parameters.properties
@@ -1,4 +1,4 @@
 NAMESPACE=NAMESPACE
 EMAIL_USER=EMAIL_USER
 EMAIL_PASSWORD=EMAIL_PASSWORD
-EMAIL_GROUPS={"engineering": "email1@foo.com", "marketing": "email2@foo.com"}.com", "marketing": "chambrid@redhat.com"}
+EMAIL_GROUPS={"engineering": "email1@foo.com", "marketing": "email2@foo.com"}

--- a/openshift/koku-daily.yaml
+++ b/openshift/koku-daily.yaml
@@ -207,6 +207,8 @@ objects:
               value: '0.0.0.0'
             - name: APP_PORT
               value: '8080'
+            - name: APP_URL_PREFIX
+              value: ${APP_URL_PREFIX}
             - name: DATABASE_HOST
               valueFrom:
                 secretKeyRef:
@@ -284,7 +286,7 @@ objects:
       protocol: TCP
       targetPort: 8080
     selector:
-      name: koku-daily
+      name: koku-daily-ui
 
 parameters:
 - description: The name assigned to all frontend objects defined in this template.
@@ -364,3 +366,6 @@ parameters:
   name: REPLICAS
   required: true
   value: '0'
+- description: The URL prefix used by the application UI
+  displayName: URL prefix
+  name: APP_URL_PREFIX


### PR DESCRIPTION
This adds the ability to specify a URL prefix so that the app generates URLs that include the prefix.

This addresses use cases where the app traffic is routed through a proxy.

Manual testing was done to confirm the functionality was working as expected:
```
2020-10-14 18:06:06,074 - __main__ - INFO - Starting server.
Running on http://0.0.0.0:8080/
2020-10-14 18:06:06,085 - __main__ - INFO - Running on http://0.0.0.0:8080/
Debugger PIN: 953-374-227
2020-10-14 18:06:06,085 - __main__ - INFO - Debugger PIN: 953-374-227
Hitting path None.
2020-10-14 18:06:27,609 - __main__ - INFO - Hitting path None.
Hitting path /api/cost-management/v1/marketing.
2020-10-14 18:06:27,609 - __main__ - INFO - Hitting path /api/cost-management/v1/marketing.
2020-10-14 18:06:27,610 - kokudaily.charts.marketing - INFO - Displaying marketing metrics.
Hitting path None.
2020-10-14 18:17:02,964 - __main__ - INFO - Hitting path None.
Hitting path /api/cost-management/v1/marketing.
2020-10-14 18:17:02,965 - __main__ - INFO - Hitting path /api/cost-management/v1/marketing.
2020-10-14 18:17:02,966 - kokudaily.charts.marketing - INFO - Displaying marketing metrics.
Hitting path /api/cost-management/v1/engineering.
2020-10-14 18:17:12,776 - __main__ - INFO - Hitting path /api/cost-management/v1/engineering.
2020-10-14 18:17:12,776 - kokudaily.charts.engineering - INFO - Displaying engineering metrics.
Hitting path /api/cost-management/v1/.
2020-10-14 18:17:33,826 - __main__ - INFO - Hitting path /api/cost-management/v1/.
Hitting path None.
2020-10-14 18:17:42,836 - __main__ - INFO - Hitting path None.
Hitting path /.
2020-10-14 18:17:42,837 - __main__ - INFO - Hitting path /.
Hitting path /api/cost-management/v1/.
2020-10-14 18:17:50,197 - __main__ - INFO - Hitting path /api/cost-management/v1/.
```