### PR TITLE
Add manifest update time check to stale provider

### DIFF
--- a/kokudaily/sql/count_stale_providers.sql
+++ b/kokudaily/sql/count_stale_providers.sql
@@ -2,7 +2,8 @@ WITH cte_manifest_temp AS (
     SELECT  DISTINCT ON(provider_id)
             provider_id,
             id,
-            manifest_completed_datetime
+            manifest_completed_datetime,
+            manifest_updated_datetime
     FROM PUBLIC.reporting_common_costusagereportmanifest
     ORDER BY provider_id,
              id
@@ -19,6 +20,7 @@ ON        t.uuid = status.provider_id
 JOIN      PUBLIC.api_customer AS cust
 ON        t.customer_id = cust.id
 WHERE     status.manifest_completed_datetime <= now() - interval '48 HOURS'
+AND       status.manifest_updated_datetime <= now() - interval '48 HOURS'
 AND       sources.koku_uuid IS NOT NULL
 GROUP BY cust.account_id, t.type, status.provider_id
 ;


### PR DESCRIPTION
## Summary
This adds a time check on a manifest being updated to the stale providers query / prom metric. This should filter out the sources that we are midway through processing but haven't finished when this query runs, effectively reducing false positives in the alert.