### PR TITLE
[COST-2851] add account_id back in for stale providers

### DIFF
--- a/kokudaily/sql/stale_providers.sql
+++ b/kokudaily/sql/stale_providers.sql
@@ -8,7 +8,8 @@ WITH cte_manifest_temp AS (
              id
     DESC NULLS LAST
 )
-SELECT    cust.org_id,
+SELECT    COALESCE(cust.account_id, 'unknown') as account_id,
+          cust.org_id,
           t.*
 FROM      PUBLIC.api_provider t
 LEFT JOIN PUBLIC.api_sources AS sources


### PR DESCRIPTION
Accidentally removed account_id from the stale providers report, added it back in with a coalesce to handle an anemic tenant.