### PR TITLE
Move org_id to end of select to enable simpler data migration

### DIFF
--- a/kokudaily/sql/active_providers.sql
+++ b/kokudaily/sql/active_providers.sql
@@ -9,9 +9,9 @@ WITH cte_manifest_temp AS (
     DESC NULLS LAST
 )
 SELECT    COALESCE(cust.account_id, 'unknown') as account_id,
-          cust.org_id,
           t.*,
-          auth.credentials->>'cluster_id' as cluster_id
+          auth.credentials->>'cluster_id' as cluster_id,
+          cust.org_id
 FROM      PUBLIC.api_provider t
 LEFT JOIN PUBLIC.api_sources AS sources
 ON        t.uuid :: text = sources.koku_uuid

--- a/kokudaily/sql/count_active_providers.sql
+++ b/kokudaily/sql/count_active_providers.sql
@@ -11,8 +11,8 @@ WITH cte_manifest_temp AS (
 SELECT    DISTINCT ON(status.provider_id)
           count (DISTINCT t.*),
           COALESCE(cust.account_id, 'unknown') as account_id,
-          cust.org_id,
-          t.type as source_type
+          t.type as source_type,
+          cust.org_id
 FROM      PUBLIC.api_provider t
 LEFT JOIN PUBLIC.api_sources AS sources
 ON        t.uuid :: text = sources.koku_uuid

--- a/kokudaily/sql/count_airgapped_clusters.sql
+++ b/kokudaily/sql/count_airgapped_clusters.sql
@@ -4,8 +4,8 @@ SELECT count (*) as "count",
        rm.operator_version,
        rm.cluster_id,
        COALESCE(c.account_id, 'unknown') as account_id,
-       c.org_id,
-       p.type as source_type
+       p.type as source_type,
+       c.org_id
   FROM
     (SELECT provider_id,
         row_number() OVER (PARTITION BY provider_id ORDER BY manifest_creation_datetime DESC) as row_number,

--- a/kokudaily/sql/count_certified_clusters.sql
+++ b/kokudaily/sql/count_certified_clusters.sql
@@ -4,8 +4,8 @@ SELECT count (*) as "count",
        rm.operator_version,
        rm.cluster_id,
        COALESCE(c.account_id, 'unknown') as account_id,
-       c.org_id,
-       p.type as source_type
+       p.type as source_type,
+       c.org_id
   FROM
     (SELECT provider_id,
         row_number() OVER (PARTITION BY provider_id ORDER BY manifest_creation_datetime DESC) as row_number,

--- a/kokudaily/sql/count_community_clusters.sql
+++ b/kokudaily/sql/count_community_clusters.sql
@@ -4,8 +4,8 @@ SELECT count (*) as "count",
        rm.operator_version,
        rm.cluster_id,
        COALESCE(c.account_id, 'unknown') as account_id,
-       c.org_id,
-       p.type as source_type
+       p.type as source_type,
+       c.org_id
   FROM
     (SELECT provider_id,
         row_number() OVER (PARTITION BY provider_id ORDER BY manifest_creation_datetime DESC) as row_number,

--- a/kokudaily/sql/count_connected_clusters.sql
+++ b/kokudaily/sql/count_connected_clusters.sql
@@ -4,8 +4,8 @@ SELECT count (*) as "count",
        rm.operator_version,
        rm.cluster_id,
        COALESCE(c.account_id, 'unknown') as account_id,
-       c.org_id,
-       p.type as source_type
+       p.type as source_type,
+       c.org_id
   FROM
     (SELECT provider_id,
         row_number() OVER (PARTITION BY provider_id ORDER BY manifest_creation_datetime DESC) as row_number,

--- a/kokudaily/sql/count_customers_by_setup_state.sql
+++ b/kokudaily/sql/count_customers_by_setup_state.sql
@@ -8,8 +8,8 @@
 filtered_customers AS (
     SELECT   c.id,
              COALESCE(c.account_id, 'unknown') as account_id,
-             c.org_id,
-             cnr.domain
+             cnr.domain,
+             c.org_id
     FROM     PUBLIC.api_customer c
     JOIN     cust_non_redhat AS cnr
     ON       cnr.customer_id = c.id

--- a/kokudaily/sql/count_errored_clusters.sql
+++ b/kokudaily/sql/count_errored_clusters.sql
@@ -4,8 +4,8 @@ SELECT count (*) as "count",
        rm.operator_version,
        rm.cluster_id,
        c.account_id,
-       c.org_id,
-       p.type as source_type
+       p.type as source_type,
+       c.org_id
   FROM
     (SELECT provider_id,
         row_number() OVER (PARTITION BY provider_id ORDER BY manifest_creation_datetime DESC) as row_number,

--- a/kokudaily/sql/count_filtered_users_by_account.sql
+++ b/kokudaily/sql/count_filtered_users_by_account.sql
@@ -23,8 +23,8 @@ filtered_customers AS (
                   cnr.domain )
 SELECT   count (DISTINCT t.username),
          fc.account_id,
-         fc.org_id,
-         fc.domain
+         fc.domain,
+         fc.org_id
 FROM     PUBLIC.api_user t
 JOIN     filtered_customers AS fc
 ON       t.customer_id = fc.id

--- a/kokudaily/sql/count_incomplete_manifests.sql
+++ b/kokudaily/sql/count_incomplete_manifests.sql
@@ -1,7 +1,7 @@
 SELECT    count (DISTINCT rm.*),
           COALESCE(c.account_id, 'unknown') as account_id,
-          c.org_id,
-          p.type as source_type
+          p.type as source_type,
+          c.org_id
 FROM      public.reporting_common_costusagereportmanifest AS rm
 JOIN      public.api_provider AS p
 ON        rm.provider_id = p.uuid

--- a/kokudaily/sql/count_internal_providers_by_type.sql
+++ b/kokudaily/sql/count_internal_providers_by_type.sql
@@ -7,8 +7,8 @@
 filtered_customers AS (
     SELECT   c.id,
              COALESCE(c.account_id, 'unknown') as account_id,
-             c.org_id,
-             cnr.domain
+             cnr.domain,
+             c.org_id
     FROM     PUBLIC.api_customer c
     JOIN     cust_redhat AS cnr
     ON       cnr.customer_id = c.id

--- a/kokudaily/sql/count_invalid_sources.sql
+++ b/kokudaily/sql/count_invalid_sources.sql
@@ -1,7 +1,7 @@
 SELECT count (DISTINCT t.source_id),
        COALESCE(t.account_id, 'unknown') as account_id,
-       COALESCE(t.org_id, 'unknown') as org_id,
-       COALESCE(NULLIF(t.source_type, ''), 'unknown') as source_type
+       COALESCE(NULLIF(t.source_type, ''), 'unknown') as source_type,
+       COALESCE(t.org_id, 'unknown') as org_id
 FROM   PUBLIC.api_sources t
 WHERE  ( t.koku_uuid IS NULL
           OR t.koku_uuid = '' )

--- a/kokudaily/sql/count_orphaned_providers.sql
+++ b/kokudaily/sql/count_orphaned_providers.sql
@@ -1,7 +1,7 @@
 SELECT count (DISTINCT t.*),
        COALESCE(cust.account_id, 'unknown') as account_id,
-       cust.org_id,
-       t.type as source_type
+       t.type as source_type,
+       cust.org_id
 FROM   public.api_provider t
        left join public.api_sources AS sources
               ON t.uuid :: text = sources.koku_uuid

--- a/kokudaily/sql/count_providers_by_filtered_account.sql
+++ b/kokudaily/sql/count_providers_by_filtered_account.sql
@@ -24,8 +24,8 @@ filtered_customers AS (
 )
 SELECT   count (DISTINCT t.uuid),
          fc.account_id,
-         fc.org_id,
-         fc.domain
+         fc.domain,
+         fc.org_id
 FROM     PUBLIC.api_provider t
 JOIN     filtered_customers AS fc
 ON       t.customer_id = fc.id

--- a/kokudaily/sql/count_providers_by_setup_state_and_filtered_account.sql
+++ b/kokudaily/sql/count_providers_by_setup_state_and_filtered_account.sql
@@ -23,14 +23,14 @@ filtered_customers AS (
                   cnr.domain )
 SELECT   count (DISTINCT t.uuid),
          fc.account_id,
-         fc.org_id,
          fc.domain,
          t.type,
          t.setup_complete,
          count (DISTINCT t.uuid) FILTER (WHERE t.type = 'OCP' AND t.setup_complete = TRUE) as ocp_setup_complete_count,
          count (DISTINCT t.uuid) FILTER (WHERE t.type = 'AWS' AND t.setup_complete = TRUE) as aws_setup_complete_count,
          count (DISTINCT t.uuid) FILTER (WHERE t.type = 'Azure' AND t.setup_complete = TRUE) as azure_setup_complete_count,
-         count (DISTINCT t.uuid) FILTER (WHERE t.type = 'GCP' AND t.setup_complete = TRUE) as gcp_setup_complete_count
+         count (DISTINCT t.uuid) FILTER (WHERE t.type = 'GCP' AND t.setup_complete = TRUE) as gcp_setup_complete_count,
+         fc.org_id
 FROM     PUBLIC.api_provider t
 JOIN     filtered_customers AS fc
 ON       t.customer_id = fc.id

--- a/kokudaily/sql/count_stale_providers.sql
+++ b/kokudaily/sql/count_stale_providers.sql
@@ -11,8 +11,8 @@ WITH cte_manifest_temp AS (
 )
 SELECT    count (DISTINCT t.*),
           COALESCE(cust.account_id, 'unknown') as account_id,
-          cust.org_id,
-          t.type as source_type
+          t.type as source_type,
+          cust.org_id
 FROM      PUBLIC.api_provider t
 LEFT JOIN PUBLIC.api_sources AS sources
 ON        t.uuid :: text = sources.koku_uuid

--- a/kokudaily/sql/cust_cost_model_report.sql
+++ b/kokudaily/sql/cust_cost_model_report.sql
@@ -27,13 +27,13 @@ filtered_customers AS (
            cnr.domain
 )
 SELECT fc.account_id,
-       fc.org_id,
        cmr.cost_model_id,
        cmr.source_type,
        cmr.created_timestamp,
        cmr.updated_timestamp,
        cmr.provider_id,
-       cmr.cluster_id
+       cmr.cluster_id,
+       fc.org_id
   FROM __cust_cost_model_report cmr
   JOIN filtered_customers AS fc
     ON fc.schema_name = cmr.customer

--- a/kokudaily/sql/cust_node_report.sql
+++ b/kokudaily/sql/cust_node_report.sql
@@ -27,14 +27,14 @@ filtered_customers AS (
            cnr.domain
 )
 SELECT fc.account_id,
-       fc.org_id,
        cnr.provider_id,
        cnr.cluster_id,
        cnr.node,
        cnr.report_month,
        cnr.pod_count,
        cnr.cpu_cores,
-       cnr.memory_bytes
+       cnr.memory_bytes,
+       fc.org_id
   FROM __cust_node_report cnr
   JOIN filtered_customers AS fc
     ON cnr.customer = fc.schema_name

--- a/kokudaily/sql/cust_providers.sql
+++ b/kokudaily/sql/cust_providers.sql
@@ -35,8 +35,7 @@ cost_report_manifest AS (
            manifest_completed_datetime
     FROM   public.reporting_common_costusagereportmanifest
 )
-SELECT    fc.account_id,
-          fc.org_id,
+SELECT    fc.account_id
           p.uuid,
           p.type,
           CASE WHEN crm.manifest_completed_datetime >= now() - interval '48 HOURS'
@@ -49,7 +48,8 @@ SELECT    fc.account_id,
           crm.assembly_id,
           crm.cluster_id,
           crm.operator_airgapped,
-          crm.operator_version
+          crm.operator_version,
+          fc.org_id
 FROM      public.api_provider p
 LEFT JOIN public.api_sources AS sources
 ON        p.uuid :: text = sources.koku_uuid

--- a/kokudaily/sql/invalid_sources.sql
+++ b/kokudaily/sql/invalid_sources.sql
@@ -1,11 +1,11 @@
 SELECT COALESCE(t.account_id, 'unknown') as account_id,
-       t.org_id,
        t.source_id,
        t.name,
        t.source_uuid,
        t.koku_uuid,
        t.source_type,
-       t.status
+       t.status,
+       t.org_id
 FROM   PUBLIC.api_sources t
 WHERE  ( t.koku_uuid IS NULL
           OR t.koku_uuid = '' )

--- a/kokudaily/sql/list_filtered_accounts.sql
+++ b/kokudaily/sql/list_filtered_accounts.sql
@@ -6,8 +6,8 @@
     GROUP BY t.customer_id
 )
 SELECT COALESCE(c.account_id, 'unknown') as account_id,
-       c.org_id,
-       cnr.domain
+       cnr.domain,
+       c.org_id
 FROM   PUBLIC.api_customer c
 JOIN   cust_non_redhat AS cnr
 ON     cnr.customer_id = c.id

--- a/kokudaily/sql/list_filtered_accounts_with_new_source_last_7_days.sql
+++ b/kokudaily/sql/list_filtered_accounts_with_new_source_last_7_days.sql
@@ -6,11 +6,11 @@ WITH cust_non_redhat AS (
     GROUP BY t.customer_id
 )
 SELECT COALESCE(c.account_id, 'unknown') as account_id,
-       c.org_id,
        cnr.domain,
        p.name,
        p.type,
-       p.setup_complete
+       p.setup_complete,
+       c.org_id
 FROM   PUBLIC.api_customer c
 JOIN   cust_non_redhat AS cnr
 ON     cnr.customer_id = c.id

--- a/kokudaily/sql/orphaned_providers.sql
+++ b/kokudaily/sql/orphaned_providers.sql
@@ -1,6 +1,6 @@
 SELECT COALESCE(cust.account_id, 'unknown') as account_id,
-       cust.org_id,
-       t.*
+       t.*,
+       cust.org_id
 FROM   public.api_provider t
        left join public.api_sources AS sources
               ON t.uuid :: text = sources.koku_uuid

--- a/kokudaily/sql/stale_providers.sql
+++ b/kokudaily/sql/stale_providers.sql
@@ -9,8 +9,8 @@ WITH cte_manifest_temp AS (
     DESC NULLS LAST
 )
 SELECT    COALESCE(cust.account_id, 'unknown') as account_id,
-          cust.org_id,
-          t.*
+          t.*,
+          cust.org_id
 FROM      PUBLIC.api_provider t
 LEFT JOIN PUBLIC.api_sources AS sources
 ON        t.uuid :: text = sources.koku_uuid


### PR DESCRIPTION
* Downstream RedShift doesn't have an org_id column
* Moving the org_id column to the end will make it simpler to adjust existing tables via migration