### PR TITLE
Fix empty timestamp errors in cust_providers

### DIFF
--- a/kokudaily/sql/cust_providers.sql
+++ b/kokudaily/sql/cust_providers.sql
@@ -44,7 +44,10 @@ SELECT    fc.account_id,
           END AS is_active,
           p.setup_complete,
           p.created_timestamp,
-          p.data_updated_timestamp,
+          CASE WHEN p.data_updated_timestamp IS NULL
+              THEN p.created_timestamp
+              ELSE p.data_updated_timestamp
+          END AS data_updated_timestamp,
           crm.assembly_id,
           crm.cluster_id,
           crm.operator_airgapped,


### PR DESCRIPTION
Should fix ```sqlalchemy.exc.DataError: (psycopg2.errors.InvalidDatetimeFormat) invalid input syntax for type timestamp: ""``` errors thrown when executing the `cust_providers` query. These error were caused by empty values of `data_updated_timestamp` present in some rows.