### PR TITLE
Remove reporting_ocpusagereport from sql.

### DIFF
--- a/kokudaily/sql/cust_node_report_setup.sql
+++ b/kokudaily/sql/cust_node_report_setup.sql
@@ -39,11 +39,6 @@ SELECT ''%%1$s'' AS "customer",
        -- starting with line item as we need the data ingestion counts
 FROM   %%1$s.reporting_ocpusagelineitem_daily_summary ro
        -- usage report has the usage bounds
-JOIN   %%1$s.reporting_ocpusagereport rp
-ON     rp.id = ro.report_id
-AND    rp.interval_start < ''%%3$s''::timestamptz  -- start must be < end bounds as end bounds is start of next month
-AND    rp.interval_end >= ''%%2$s''::timestamptz   -- end must be >= start bounds
-       -- report period has the provider and cluster
 JOIN   %%1$s.reporting_ocpusagereportperiod rpp
 ON     rpp.id = ro.report_period_id
 GROUP

--- a/kokudaily/sql/cust_node_report_setup.sql
+++ b/kokudaily/sql/cust_node_report_setup.sql
@@ -6,7 +6,6 @@ CREATE TEMPORARY TABLE IF NOT EXISTS __cust_node_report (
     cluster_id text,
     node text,
     report_month date,
-    pod_count bigint,
     cpu_cores bigint,
     memory_gigabytes bigint
 );
@@ -24,7 +23,6 @@ INSERT
       cluster_id,
       node,
       report_month,
-      pod_count,
       cpu_cores,
       memory_gigabytes
   )
@@ -33,12 +31,13 @@ SELECT ''%%1$s'' AS "customer",
        rpp.cluster_id AS "cluster_id",
        ro.node as "node",
        date_trunc(''month'', rpp.report_period_start)::date AS "report_month",
-       0 AS "pod_count",
        max(ro.node_capacity_cpu_cores) AS "cpu_cores",
        max(ro.node_capacity_memory_gigabytes) AS "memory_gigabytes"
 FROM   %%1$s.reporting_ocpusagelineitem_daily_summary ro
 JOIN   %%1$s.reporting_ocpusagereportperiod rpp
 ON     rpp.id = ro.report_period_id
+WHERE ro.usage_start < ''%%3$s''::timestamptz
+AND ro.usage_start >= ''%%2$s''::timestamptz
 GROUP
    BY "customer",
       "provider_id",


### PR DESCRIPTION
Remove old table from sql:

```
postgres=# select count(*) from __cust_node_report;
 count
-------
   240
(1 row)

postgres=# \d+ __cust_node_report
                               Table "pg_temp_29.__cust_node_report"
      Column      |  Type  | Collation | Nullable | Default | Storage  | Stats target | Description
------------------+--------+-----------+----------+---------+----------+--------------+-------------
 customer         | text   |           |          |         | extended |              |
 provider_id      | text   |           |          |         | extended |              |
 cluster_id       | text   |           |          |         | extended |              |
 node             | text   |           |          |         | extended |              |
 report_month     | date   |           |          |         | plain    |              |
 pod_count        | bigint |           |          |         | plain    |              |
 cpu_cores        | bigint |           |          |         | plain    |              |
 memory_gigabytes | bigint |           |          |         | plain    |              |
Indexes:
    "ix__cust_node_report" btree (customer, provider_id, cluster_id, node, report_month)
Access method: heap
```