### PR TITLE
[COST-6239] fix cannot extract elements from an object

### DIFF
--- a/kokudaily/sql/cust_cost_model_report_counts.sql
+++ b/kokudaily/sql/cust_cost_model_report_counts.sql
@@ -13,7 +13,7 @@ filtered_customers AS (
            c.schema_name,
            cnr.domain
     FROM   public.api_customer c
-    JOIN   cust_non_redhat AS cnr
+    LEFT JOIN   cust_non_redhat AS cnr
     ON     cnr.customer_id = c.id
     WHERE  c.org_id NOT IN ('11789772',
                             '6340056',
@@ -44,6 +44,7 @@ cte_tag_rates AS (
     FROM (
         SELECT customer, cost_model_id, cost_model_map_id, jsonb_array_elements(rates)->'tag_rates' as has_tag_rate
         FROM __cust_cost_model_report cmr
+        WHERE jsonb_typeof(rates) = 'array'
     ) as sub
     WHERE has_tag_rate IS NOT NULL
     GROUP BY customer


### PR DESCRIPTION
testing:
1. `$ make create-test-customer; make load-test-customer-data test_source=aws`
2. update a cost model:
```
postgres=# update org1234567_mskarbek.cost_model set rates = '{"tag_rates": "thing"}'::jsonb;
UPDATE 2
postgres=# 
```
3. run weekly report:
```
$ WEEKLY_REPORT_SCHEDULED_DAY=1 RUN_DAILY_REPORTS=true LOGLEVEL=DEBUG python3 job.py
```
4. see this:
```
2025-04-22 11:42:48,698 - kokudaily.reports - INFO - report_sql_file=sql/cust_cost_model_report_counts.sql.
2025-04-22 11:42:48,702 - kokudaily.reports - DEBUG - /var/folders/rw/lj_rj3z50z302ypg61hl25j40000gn/T/reports/cust_cost_model_counts_report.csv
```
5. see that the report is mostly populated

note: We no longer save `User`s, so the `api_user` table is empty locally. In this cost-model sql, this table is used to filter results to non-redhat users. I updated the sql to use a left join here so that we can still filter out redhat email, but capture data for cost models that were created after we stopped saving the `User`s.

## Summary by Sourcery

Fix cost model report SQL to handle empty or invalid JSON and support cost models created after user tracking changes

Bug Fixes:
- Modify SQL query to use LEFT JOIN to ensure cost model reports can be generated even when the api_user table is empty
- Add a type check to prevent errors when processing JSON rates that are not in the expected format

Enhancements:
- Improve robustness of cost model reporting SQL by adding defensive JSON parsing