### PR TITLE
[COST-6266] - compress csvs prior to attaching to email

### DIFF
--- a/job.py
+++ b/job.py
@@ -37,7 +37,14 @@ for target, report_dict in report_data.items():
         prometheus(target, report_name, **report)
         s3(target, report_name, **report)
     zip_file_path = create_zip_archive(report_files, "koku_metrics.zip")
-    email(recipients, attachments=[zip_file_path], target=target)
+    if zip_file_path:
+        LOG.info("Proceeding to email the compressed zip file.")
+        email(recipients, attachments=[zip_file_path], target=target)
+    else:
+        LOG.error(
+            "Skipping email because the zip archive could not be created."
+        )
+
     if Config.PROMETHEUS_PUSH_GATEWAY:
         push_to_gateway(
             Config.PROMETHEUS_PUSH_GATEWAY,

--- a/kokudaily/send.py
+++ b/kokudaily/send.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import smtplib
+import tempfile
 import zipfile
 from datetime import date
 from email.encoders import encode_base64
@@ -159,7 +160,7 @@ def create_zip_archive(files_to_zip, zip_filename):
         LOG.warning("No files provided to zip.")
         return None
     try:
-        zip_filepath = os.path.join("/tmp", zip_filename)
+        zip_filepath = os.path.join(tempfile.gettempdir(), zip_filename)
         LOG.info(f"Creating zip archive at: {zip_filepath}")
         with zipfile.ZipFile(zip_filepath, "w", zipfile.ZIP_DEFLATED) as zipf:
             for file_path in files_to_zip:


### PR DESCRIPTION
## Summary by Sourcery

Compress report CSV files into a single zip archive and email that archive instead of multiple attachments

New Features:
- Introduce create_zip_archive function to bundle report CSVs into a compressed zip archive before emailing

Enhancements:
- Update email step to send the generated zip archive instead of individual CSV report files